### PR TITLE
Add support for macapp format

### DIFF
--- a/signing-manifests/example-macapp.yml.tmpl
+++ b/signing-manifests/example-macapp.yml.tmpl
@@ -1,0 +1,14 @@
+---
+bug: 12345
+sha256: 2029107d065e35b5e0947ac15a116ac8f6c1bc03f8b008c9c49fc0f51999be70
+filesize: 1222505
+private-artifact: false
+signing-formats: ["macapp"]
+requestor: Ben Hearsum <bhearsum@mozilla.com>
+reason: test mac signing
+artifact-name: wireguard.tar.gz
+mac-entitlements-url: https://gist.githubusercontent.com/bhearsum/5b361f5834a467dd1a731810c2126ab9/raw/c3f68a4f9f8e5fcb5af8cd27aecf9d5bbd42c8e6/gistfile1.txt
+mac-behavior: mac_notarize
+product: mozillavpn
+fetch:
+  url: https://hearsum.ca/~bhearsum/wireguard.tar.gz

--- a/taskcluster/adhoc_taskgraph/signing_manifest.py
+++ b/taskcluster/adhoc_taskgraph/signing_manifest.py
@@ -32,6 +32,7 @@ SUPPORTED_SIGNING_FORMATS = (
     "autograph_authenticode",
     "autograph_authenticode_stub",
     "autograph_hash_only_mar384",
+    "macapp",
 )
 
 
@@ -57,6 +58,9 @@ base_schema = Schema(
             }
         ),
         Required("manifest_name"): basestring,
+        Optional("mac-behavior"): text_type,
+        Optional("product"): text_type,
+        Optional("mac-entitlements-url"): text_type,
     }
 )
 

--- a/taskcluster/adhoc_taskgraph/transforms/signing.py
+++ b/taskcluster/adhoc_taskgraph/transforms/signing.py
@@ -28,12 +28,15 @@ def define_signing_flags(config, tasks):
         if "run_on_tasks_for" in task["attributes"]:
             task.setdefault("run-on-tasks-for", task["attributes"]["run_on_tasks_for"])
 
+        # XXX: hack alert, we're taking a list and turning into a single item
+        format_ = "macapp" if "macapp" in task["attributes"]["manifest"]["signing-formats"] else ""
         for key in ("worker-type", "worker.signing-type"):
             resolve_keyed_by(
                 task,
                 key,
                 item_name=task["name"],
                 level=config.params["level"],
+                format=format_,
             )
         yield task
 
@@ -59,6 +62,12 @@ def build_signing_task(config, tasks):
                 "formats": manifest["signing-formats"],
             }
         ]
+        if "mac-behavior" in manifest:
+            task["worker"]["mac-behavior"] = manifest["mac-behavior"]
+        if "mac-entitlements-url" in manifest:
+            task["worker"]["entitlements-url"] = manifest["mac-entitlements-url"]
+        if "product" in manifest:
+            task["worker"]["product"] = manifest["product"]
         task.setdefault("label", "{}-{}".format(config.kind, manifest_name))
         task.setdefault("extra", {})["manifest-name"] = manifest_name
         del task["primary-dependency"]

--- a/taskcluster/adhoc_taskgraph/worker_types.py
+++ b/taskcluster/adhoc_taskgraph/worker_types.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from six import text_type
 
-from voluptuous import Required
+from voluptuous import Any, Optional, Required
 
 from taskgraph.util.schema import taskref_or_string
 from taskgraph.util import path as mozpath
@@ -32,6 +32,14 @@ from taskgraph.transforms.task import payload_builder
                 Required("formats"): [text_type],
             }
         ],
+        # behavior for mac iscript
+        Optional("mac-behavior"): Any(
+            # Adhoc signing doesn't have enough contention to warrant
+            # splitting this into part 1 & part 3
+            "mac_notarize",
+        ),
+        Optional("product"): text_type,
+        Optional("entitlements-url"): text_type,
     },
 )
 def build_scriptworker_signing_payload(config, task, task_def):
@@ -43,6 +51,12 @@ def build_scriptworker_signing_payload(config, task, task_def):
         "maxRunTime": worker["max-run-time"],
         "upstreamArtifacts": worker["upstream-artifacts"],
     }
+    if worker.get("mac-behavior"):
+        task_def["payload"]["behavior"] = worker["mac-behavior"]
+        if worker.get("product"):
+            task_def["payload"]["product"] = worker["product"]
+        if worker.get("entitlements-url"):
+            task_def["payload"]["entitlements-url"] = worker["entitlements-url"]
 
     formats = set()
     for artifacts in worker["upstream-artifacts"]:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -50,6 +50,16 @@ workers:
                 by-level:
                     "3": adhoc-3-signing
                     default: adhoc-t-signing
+        mac-signing:
+            provisioner: scriptworker-prov-v1
+            implementation: scriptworker-signing
+            os: macosx
+            # We don't need a separate worker type
+            # for level 1 because RelEng are the only
+            # people who can pick off signing requests.
+            # This means that there's no security benefit
+            # to separating the level 1 / level 3 workers.
+            worker-type: adhoc-3-mac-signing
         shipit:
             provisioner: scriptworker-k8s
             implementation: scriptworker-shipit

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -10,26 +10,11 @@ task-priority: high
 taskgraph:
     register: adhoc_taskgraph:register
     repositories:
-        # This is the manifest repo
-        adhoc-manifest:
-            name: "Adhoc manifest"
-            project-regex: adhoc-manifest$
-            default-repository: https://github.com/mozilla-releng/adhoc-manifest
-            default-ref: master
-            ssh-secret-name: project/adhoc/adhoc-github-clone-ssh
-            type: git
         adhoc-signing:
             name: "Adhoc Signing"
             project-regex: adhoc-signing$
             default-repository: https://github.com/mozilla-releng/adhoc-signing
             default-ref: master
-            type: git
-        staging-adhoc-manifest:
-            name: "Staging adhoc manifest"
-            project-regex: adhoc-manifest$
-            default-repository: https://github.com/mozilla-releng/adhoc-manifest
-            default-ref: master
-            ssh-secret-name: project/adhoc/adhoc-github-clone-ssh
             type: git
         staging-adhoc-signing:
             # string: the name of the repo, for humans

--- a/taskcluster/ci/dep-signing/kind.yml
+++ b/taskcluster/ci/dep-signing/kind.yml
@@ -18,7 +18,10 @@ job-template:
         code-review: true
     index:
         type: dep-signing
-    worker-type: dep-signing
+    worker-type:
+        by-format:
+            macapp: mac-signing
+            default: dep-signing
     worker:
         signing-type: dep-signing
         max-run-time: 3600

--- a/taskcluster/ci/release-signing/kind.yml
+++ b/taskcluster/ci/release-signing/kind.yml
@@ -21,9 +21,12 @@ job-template:
         shipping-phase: promote
     run-on-tasks-for: [action]
     worker-type:
-        by-level:
-            '3': signing
-            default: dep-signing
+        by-format:
+            macapp: mac-signing
+            default:
+                by-level:
+                    '3': signing
+                    default: dep-signing
     worker:
         signing-type:
             by-level:
@@ -33,4 +36,3 @@ job-template:
     notifications:
         subject: "{config[graph_config][notify][prefix]} {config[params][adhoc_name]} release-signing starting"
         message: "{config[graph_config][notify][prefix]} {config[params][adhoc_name]} release-signing {config[params][shipping_phase]} starting on revision {config[params][adhoc_revision]}"
-


### PR DESCRIPTION
I think this is pretty straightforward. The only thing I really want to call out is that I'm pretty sure we can use the same worker for level 1 & level 3 signing. RelEng are the only people who can initiate these requests, so I don't see any security benefit to having separate workers for dep vs release. If I'm wrong or missing something, just let me know.

Unrelated to the work here, the first commits removes what appears to be an unused part of the config (we tried to put manifests elsewhere at one point it looks like? but never used them?)