### PR TITLE
Only generate pull-request graphs on certain actions

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -10,75 +10,81 @@ tasks:
               revision: 81f2a1a09e9b0fc1b6c66fd452e065440793c175
           trustDomain: adhoc
       in:
-          $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
-          then:
-              $let:
-                  # Github events have this stuff in different places...
-                  ownerEmail:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.pusher.email}'
-                      # Assume Pull Request
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.user.login}@users.noreply.github.com'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${tasks_for}@noreply.mozilla.org'
-                  baseRepoUrl:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.repository.html_url}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.base.repo.html_url}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${repository.url}'
-                  repoUrl:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.repository.html_url}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.head.repo.html_url}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${repository.url}'
-                  project:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.repository.name}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.head.repo.name}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${repository.project}'
-                  head_branch:
+          $let:
+              # Github events have this stuff in different places...
+              ownerEmail:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.pusher.email}'
+                  # Assume Pull Request
+                  else:
                       $if: 'tasks_for == "github-pull-request"'
-                      then: ${event.pull_request.head.ref}
-                      else:
-                          $if: 'tasks_for == "github-push"'
-                          then: ${event.ref}
-                          else:
-                              $if: 'tasks_for == "cron"'
-                              then: '${push.branch}'
-                              else:
-                                  $if: 'tasks_for == "action"'
-                                  then: 'refs/heads/master'  # TODO fix
-                  head_sha:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.after}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.head.sha}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${push.revision}'
-                  ownTaskId:
-                      $if: '"github" in tasks_for'
-                      then: {$eval: as_slugid("decision_task")}
+                      then: '${event.pull_request.user.login}@users.noreply.github.com'
                       else:
                           $if: 'tasks_for in ["cron", "action"]'
-                          then: '${ownTaskId}'
-              in:
+                          then: '${tasks_for}@noreply.mozilla.org'
+              baseRepoUrl:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.repository.html_url}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.base.repo.html_url}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${repository.url}'
+              repoUrl:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.repository.html_url}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.head.repo.html_url}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${repository.url}'
+              project:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.repository.name}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.head.repo.name}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${repository.project}'
+              head_branch:
+                  $if: 'tasks_for == "github-pull-request"'
+                  then: ${event.pull_request.head.ref}
+                  else:
+                      $if: 'tasks_for == "github-push"'
+                      then: ${event.ref}
+                      else:
+                          $if: 'tasks_for == "cron"'
+                          then: '${push.branch}'
+                          else:
+                              $if: 'tasks_for == "action"'
+                              then: 'refs/heads/master'  # TODO fix
+              head_sha:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.after}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.head.sha}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${push.revision}'
+              ownTaskId:
+                  $if: '"github" in tasks_for'
+                  then: {$eval: as_slugid("decision_task")}
+                  else:
+                      $if: 'tasks_for in ["cron", "action"]'
+                      then: '${ownTaskId}'
+              pullRequestAction:
+                  $if: 'tasks_for == "github-pull-request"'
+                  then: ${event.action}
+                  else: 'UNDEFINED'
+          in:
+              $if: >
+                tasks_for in ["github-push", "action", "cron"]
+                || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
+              then:
                   $let:
                       level:
                           $if: 'tasks_for in ["github-push", "cron", "action"] && repoUrl == "https://github.com/mozilla-releng/adhoc-signing"'


### PR DESCRIPTION
This moves variable definitions before the `if` guard so we can use them to filter on certain pull request actions.