### PR TITLE
Add manifests for NSIS core plugins

### DIFF
--- a/signing-manifests/bug1751450-nsis-core-ansi.yml
+++ b/signing-manifests/bug1751450-nsis-core-ansi.yml
@@ -1,0 +1,12 @@
+---
+bug: 1751450
+sha256: 0400b1359925b559cb19499fbbb60e99ddde1029595677e81140ab1093757fe6
+filesize: 92466
+private-artifact: false
+signing-formats: ["autograph_authenticode_sha2"]
+requestor: Ben Hearsum <ben@mozilla.com>
+reason: One-off signing of core NSIS ansi plugins that we ship
+artifact-name: core-ansi-signed.zip
+fetch:
+  type: static-url
+  url: https://github.com/mozilla-releng/adhoc-signing-blobs/raw/nsis/core-ansi.zip

--- a/signing-manifests/bug1751450-nsis-core-unicode.yml
+++ b/signing-manifests/bug1751450-nsis-core-unicode.yml
@@ -1,0 +1,12 @@
+---
+bug: 1751450
+sha256: 32cb3ef3bf600e65678b1f2cc0de723c9acebe3245084336add1bed0a182ccce
+filesize: 94571
+private-artifact: false
+signing-formats: ["autograph_authenticode_sha2"]
+requestor: Ben Hearsum <ben@mozilla.com>
+reason: One-off signing of core NSIS unicode plugins that we ship
+artifact-name: core-unicode-signed.zip
+fetch:
+  type: static-url
+  url: https://github.com/mozilla-releng/adhoc-signing-blobs/raw/nsis/core-unicode.zip


### PR DESCRIPTION
The blobs these reference were created by:
- Downloading [the current NSIS Windows zip we use](https://searchfox.org/mozilla-central/rev/9902932742fcdce2c956eeb81fd38350f5394ab2/taskcluster/ci/fetch/toolchains.yml#215)
- Extracting it
- Putting the DLLs in `nsis-3.07/Plugins/x86-ansi` into core-ansi.zip
- Putting the DLLs in `nsis-3.07/Plugins/x86-unicode` into core-unicode.zip