### PR TITLE
Add signing manifest for Microsoft Hardware Developer Program test file

### DIFF
--- a/signing-manifests/itsec-404.yml
+++ b/signing-manifests/itsec-404.yml
@@ -1,0 +1,12 @@
+---
+bug: 0
+sha256: 979b6e79e39c109fa82646af3289ac4bf6c421815419eab3eaf5d312cbb8849e
+filesize: 4096
+private-artifact: false
+signing-formats: ["autograph_authenticode_sha2"]
+requestor: Andrew Halberstadt <ahal@mozilla.com>
+reason: Needed to register for the Microsoft Hardware Developer program (ITSEC-404)
+artifact-name: SignableFile.bin
+fetch:
+    type: static-url
+    url: https://github.com/mozilla-releng/adhoc-signing-blobs/raw/vpn-split-tunnel/SignableFile.bin


### PR DESCRIPTION
This is a test file that we need to sign in order to prove we own an EV certificate. We don't have a dep EV certificate so I'm assuming the task will fail on this PR and we'll need to actually merge it before we can test.