### PR TITLE
Stop pretending release-promotion supports a `revision` input

### DIFF
--- a/taskcluster/adhoc_taskgraph/parameters.py
+++ b/taskcluster/adhoc_taskgraph/parameters.py
@@ -10,11 +10,9 @@ from voluptuous import (
 )
 
 
-# Please keep this list sorted and in sync with taskcluster/docs/parameters.rst
 adhoc_schema = {
     Optional('shipping_phase'): Any("build", "promote", None),
     Optional('adhoc_name'): Any(str, None),
-    Optional('adhoc_revision'): Any(str, None),
 }
 
 extend_parameters_schema(adhoc_schema)

--- a/taskcluster/adhoc_taskgraph/release_promotion.py
+++ b/taskcluster/adhoc_taskgraph/release_promotion.py
@@ -62,11 +62,6 @@ def is_release_promotion_available(parameters):
                     manifest_name for manifest_name in ADHOC_MANIFEST.keys()
                 ),
             },
-            'revision': {
-                'type': 'string',
-                'title': 'Optional: revision to promote',
-                'description': ('Optional: the revision to promote.'),
-            },
             'release_promotion_flavor': {
                 'type': 'string',
                 'description': 'The flavor of release promotion to perform.',
@@ -111,7 +106,7 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
 
     # make parameters read-write
     parameters = dict(parameters)
-    # Build previous_graph_ids from ``previous_graph_ids`` or ``revision``.
+    # Build previous_graph_ids from ``previous_graph_ids`` or ``head_rev``.
     previous_graph_ids = input.get('previous_graph_ids')
     if not previous_graph_ids:
         previous_graph_ids = [find_decision_task(parameters, graph_config)]
@@ -138,11 +133,6 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
     # previous graphs.
     parameters['optimize_target_tasks'] = True
     parameters['adhoc_name'] = input['adhoc_name']
-    # TODO
-    #  - require this is a specific revision
-    #  - possibly also check that this is on a reviewed PR or merged into
-    #    a trusted branch. this will require an oauth token
-    parameters['adhoc_revision'] = input.get('revision', 'master')
     parameters['shipping_phase'] = input['release_promotion_flavor']
 
     if input.get('version'):

--- a/taskcluster/adhoc_taskgraph/routes.py
+++ b/taskcluster/adhoc_taskgraph/routes.py
@@ -25,7 +25,7 @@ def add_signing_indexes(config, task, variant):
         "%Y.%m.%d", time.gmtime(config.params["build_date"])
     )
     subs["trust-domain"] = config.graph_config["trust-domain"]
-    subs["revision"] = config.params.get("adhoc_revision") or "unknown"
+    subs["revision"] = config.params["head_rev"]
     subs["variant"] = variant
     manifest_name = task.get("extra", {}).get("manifest-name")
     if manifest_name:

--- a/taskcluster/ci/release-signing/kind.yml
+++ b/taskcluster/ci/release-signing/kind.yml
@@ -38,4 +38,4 @@ task-template:
         max-run-time: 3600
     notifications:
         subject: "{config[graph_config][notify][prefix]} {config[params][adhoc_name]} release-signing starting"
-        message: "{config[graph_config][notify][prefix]} {config[params][adhoc_name]} release-signing {config[params][shipping_phase]} starting on revision {config[params][adhoc_revision]}"
+        message: "{config[graph_config][notify][prefix]} {config[params][adhoc_name]} release-signing {config[params][shipping_phase]} starting on revision {config[params][head_rev]}"


### PR DESCRIPTION
We were not actually using it for anything other than email notification contents and index path, so just replace that with params["head_rev"] instead.