### PR TITLE
Bug 1873639 - Sign channel-switching MARs for Thunderbird 115 monthly releases

### DIFF
--- a/signing-manifests/bug1873639-2.yml
+++ b/signing-manifests/bug1873639-2.yml
@@ -1,13 +1,13 @@
 ---
 bug: 1873639
-sha256: 7c4d0d8136222aee631354a93abe4fba6dc4f5da3d502bf8106ee6fc29eee9aa
-filesize: 2094
+sha256: 3c6c9793e0e44c8f356fe39e5244d51256f977709a2ac8afed5e977999d78fea
+filesize: 2092
 private-artifact: false
 signing-formats: ["autograph_hash_only_mar384"]
 signing-cert: release-signing
 requestor: Daniel Darnell <daniel@thunderbird.net>
 reason: Thunderbird channel-switching from comm-release to comm-esr115, dist-id comm-mac-eol-esr115
-artifact-name: switch-to-esr115.8.0-eol-mac.mar
+artifact-name: switch-to-esr116.0-eol-mac.mar
 fetch:
     type: bmo-attachment
-    attachment-id: 9380436
+    attachment-id: 9390141

--- a/signing-manifests/bug1873639-2.yml
+++ b/signing-manifests/bug1873639-2.yml
@@ -1,0 +1,13 @@
+---
+bug: 1873639
+sha256: 7c4d0d8136222aee631354a93abe4fba6dc4f5da3d502bf8106ee6fc29eee9aa
+filesize: 2094
+private-artifact: false
+signing-formats: ["autograph_hash_only_mar384"]
+signing-cert: release-signing
+requestor: Daniel Darnell <daniel@thunderbird.net>
+reason: Thunderbird channel-switching from comm-release to comm-esr115, dist-id comm-mac-eol-esr115
+artifact-name: switch-to-esr115.8.0-eol-mac.mar
+fetch:
+    type: bmo-attachment
+    attachment-id: 9380436

--- a/signing-manifests/bug1873639-3.yml
+++ b/signing-manifests/bug1873639-3.yml
@@ -1,0 +1,13 @@
+---
+bug: 1873639
+sha256: 808ffe831767fae8b1667d79702eb8236bb03a23b86c43fd560454835073d00b
+filesize: 2094
+private-artifact: false
+signing-formats: ["autograph_hash_only_mar384"]
+signing-cert: release-signing
+requestor: Daniel Darnell <daniel@thunderbird.net>
+reason: Thunderbird channel-switching from comm-release to comm-esr115, dist-id comm-win-eol-esr115
+artifact-name: switch-to-esr115.8.0-eol-win.mar
+fetch:
+    type: bmo-attachment
+    attachment-id: 9380437

--- a/signing-manifests/bug1873639-3.yml
+++ b/signing-manifests/bug1873639-3.yml
@@ -1,13 +1,13 @@
 ---
 bug: 1873639
-sha256: 808ffe831767fae8b1667d79702eb8236bb03a23b86c43fd560454835073d00b
-filesize: 2094
+sha256: d40e1848612021a0bcf650755eed3c35f0f73e542a08e9f143044db70380ffb8
+filesize: 2092
 private-artifact: false
 signing-formats: ["autograph_hash_only_mar384"]
 signing-cert: release-signing
 requestor: Daniel Darnell <daniel@thunderbird.net>
 reason: Thunderbird channel-switching from comm-release to comm-esr115, dist-id comm-win-eol-esr115
-artifact-name: switch-to-esr115.8.0-eol-win.mar
+artifact-name: switch-to-esr116.0-eol-win.mar
 fetch:
     type: bmo-attachment
-    attachment-id: 9380437
+    attachment-id: 9390142

--- a/signing-manifests/bug1873639.yml
+++ b/signing-manifests/bug1873639.yml
@@ -1,13 +1,13 @@
 ---
 bug: 1873639
-sha256: bcc687023beb35cd1117c1a2e8d91c3b39d230a11113364a4370c8aab1897a80
-filesize: 1591
+sha256: 389f36877da1622f1f7909d42b9bd7ab8f519386972188fc51982874015530c5
+filesize: 1589
 private-artifact: false
 signing-formats: ["autograph_hash_only_mar384"]
 signing-cert: release-signing
 requestor: Daniel Darnell <daniel@thunderbird.net>
 reason: Thunderbird channel-switching from comm-release to comm-esr115, no distribution id
-artifact-name: switch-to-esr115.8.0-eol.mar
+artifact-name: switch-to-esr116.0-eol.mar
 fetch:
     type: bmo-attachment
-    attachment-id: 9380435
+    attachment-id: 9390140

--- a/signing-manifests/bug1873639.yml
+++ b/signing-manifests/bug1873639.yml
@@ -1,0 +1,13 @@
+---
+bug: 1873639
+sha256: bcc687023beb35cd1117c1a2e8d91c3b39d230a11113364a4370c8aab1897a80
+filesize: 1591
+private-artifact: false
+signing-formats: ["autograph_hash_only_mar384"]
+signing-cert: release-signing
+requestor: Daniel Darnell <daniel@thunderbird.net>
+reason: Thunderbird channel-switching from comm-release to comm-esr115, no distribution id
+artifact-name: switch-to-esr115.8.0-eol.mar
+fetch:
+    type: bmo-attachment
+    attachment-id: 9380435


### PR DESCRIPTION
New MARs for Thunderbird are unfortunately needed, as infra changes weren't ready before Thunderbird 115.8.1 released. These are new MARs for 115.8.1 instead of 115.8.0.