### PR TITLE
bug 1896868: Add signing manifest for net InetBgDL nsis plugin, round 2.

### DIFF
--- a/signing-manifests/bug1896868.yml
+++ b/signing-manifests/bug1896868.yml
@@ -1,0 +1,12 @@
+---
+bug: 1896868
+sha256: cffa9387a806907396a029b3c75c7bb5736fd5ae134973863b8b455a7ea09612
+filesize: 46854
+private-artifact: false
+signing-formats: ["autograph_authenticode_sha2"]
+requestor: Ben Hearsum <ben@mozilla.com>
+reason: One-off signing of an updated version of the InetBgDL nsis plugin, round 2
+artifact-name: inetbgdl-signed.zip
+fetch:
+  type: static-url
+  url: https://github.com/mozilla-releng/adhoc-signing-blobs/raw/inetbgdl2/inetbgdl2.zip


### PR DESCRIPTION
The unsigned version of this comes from `setup-stub.exe` in https://treeherder.mozilla.org/jobs?repo=try&revision=0d8c6bee15ce9bc54a7749717033fa24e15ca0bf&selectedTaskRun=BcjAU6GNT52-Zhtz8z3q8A.0