### PR TITLE
new manifest for bug 1912260

### DIFF
--- a/signing-manifests/bug1912260.yml
+++ b/signing-manifests/bug1912260.yml
@@ -5,7 +5,7 @@ filesize: 105750413
 private-artifact: false
 signing-formats: ["autograph_apk"]
 requestor: Geoff Brown <gbrown@mozilla.com>
-reason: sign Fenix Beta with extra logging to support debugging
+reason: sign Fenix Beta with extra logging to support debugging, with the right cert
 artifact-name: fenix-beta-with-logging-and-signed.arm64-v8a.apk
 fetch:
     type: static-url


### PR DESCRIPTION
i managed to screw up reruns in the original task group: https://firefox-ci-tc.services.mozilla.com/tasks/groups/JaNZNU1JTFSHTJKTD9zyyQ

we need a new push to main to make this signing work